### PR TITLE
Run bash as login shell inside container

### DIFF
--- a/utils/travis-build-repo-internal.sh
+++ b/utils/travis-build-repo-internal.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -l
 
 set -eux
 

--- a/utils/travis-build-repo.sh
+++ b/utils/travis-build-repo.sh
@@ -53,4 +53,4 @@ python run.py -p $REPO_PACKAGE_NAME --name ${CONTAINER_NAME} \
     -e "REPO_DOC_CMD=$REPO_DOC_CMD" \
     -e "GIT_BRANCH=$TRAVIS_BRANCH" \
     -v $PWD:$REPO_PATH \
-    bash $REPO_PATH/travis-build-repo-internal.sh $REPO_PATH
+    bash -l $REPO_PATH/travis-build-repo-internal.sh $REPO_PATH


### PR DESCRIPTION
This is necessary to invoke some initialization in /etc/profile.d/
required for using the OPAM repository provided by xs-opam-repo.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>